### PR TITLE
:recycle: Renew .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,16 @@
-/vendor
-/.gopath~
-/bin
-Jenkinsfile
-Dockerfile
-README.md
-/ci-cd
-.dockerignore
+# ignore everything
+*
+
+# add startup script
+!entrypoint.sh
+
+# add go dependencies
+!go.mod
+!go.sum
+
+# add application code
+!cmd/
+!conf/
+!internal/
+!pkg/
+!test/


### PR DESCRIPTION
This changes the strategy of adding files to the container build environment and ignores all files by default. With this change, files have to be explicitly added to the environment, saving us from accidentally adding unneeded files.